### PR TITLE
Show error when we're missing Tina Cloud env

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -7,9 +7,26 @@ export const createClient = () => {
 };
 
 export const createCloudClient = () => {
+  
+  const realm = process.env.NEXT_PUBLIC_REALM_NAME
+  const clientId = process.env.NEXT_PUBLIC_TINA_CLIENT_ID
+
+  const missingEnv : string[] = []
+  if(!realm) {
+    missingEnv.push('NEXT_PUBLIC_REALM_NAME')
+  }
+  if(!clientId) {
+    missingEnv.push('NEXT_PUBLIC_TINA_CLIENT_ID')
+  }
+
+  if(missingEnv.length) {
+    throw new Error(`The following environment variables are required when using the Tina Cloud Client: 
+     ${missingEnv.join(', ')}`)
+  }
+
   return new Client({
-    realm: process.env.NEXT_PUBLIC_REALM_NAME,
-    clientId: process.env.NEXT_PUBLIC_TINA_CLIENT_ID,
+    realm,
+    clientId,
     branch: "main",
     tokenStorage: "LOCAL_STORAGE",
   });


### PR DESCRIPTION
Show error when we're missing Tina Cloud env. Without this, it's a bit of a cryptic error from the underlying graphql query
<img width="979" alt="Screen Shot 2021-01-28 at 9 38 21 PM" src="https://user-images.githubusercontent.com/3323181/106220110-2868e200-61b1-11eb-80a9-4084957e9409.png">
