### PR TITLE
bump tina-graphql-gateway version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "styled-components": "^5.1.3",
     "styled-jsx": "^3.2.5",
     "tailwindcss": "^1.4.6",
-    "tina-graphql-gateway": "^0.1.48",
+    "tina-graphql-gateway": "^0.1.50",
     "tinacms": "0.31.0",
     "typescript": "^3.8.3",
     "urql": "^1.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5318,12 +5318,12 @@ filter-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-2.0.1.tgz#34d9f0536786f072df7aeac3a8bda1c6e767aec6"
   integrity sha512-yDEp513p7+iLdFHWBVdZFnRiOYwg8ZqmpaAiZCMjzqsbo7tCS4Qm4ulXOht337NGzkukKa9u3W4wqQ9tQPm3Ug==
 
-final-form-arrays@^3.0.1:
+final-form-arrays@^3.0.1, final-form-arrays@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/final-form-arrays/-/final-form-arrays-3.0.2.tgz#9f3bef778dec61432357744eb6f3abef7e7f3847"
   integrity sha512-TfO8aZNz3RrsZCDx8GHMQcyztDNpGxSSi9w4wpSNKlmv2PfFWVVM8P7Yj5tj4n0OWax+x5YwTLhT5BnqSlCi+w==
 
-final-form@4.20.1, final-form@^4.18.2:
+final-form@^4.18.2, final-form@^4.20.1:
   version "4.20.1"
   resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.20.1.tgz#525a7f7f27f55c28d8994b157b24d6104fc560e9"
   integrity sha512-IIsOK3JRxJrN72OBj7vFWZxtGt3xc1bYwJVPchjVWmDol9DlzMSAOPB+vwe75TUYsw1JaH0fTQnIgwSQZQ9Acg==
@@ -12295,10 +12295,10 @@ tina-graphql-gateway-cli@^0.2.27:
     yaml "^1.10.0"
     yo "^3.1.1"
 
-tina-graphql-gateway@^0.1.48:
-  version "0.1.48"
-  resolved "https://registry.yarnpkg.com/tina-graphql-gateway/-/tina-graphql-gateway-0.1.48.tgz#68cc98cddf446baadb2cde5448b6a2a1f519d5c5"
-  integrity sha512-QoHmTQ2iTerocsrGiEp9vbD0YMQ9P3xMTGBA83XFQeXRXZBqaOHRUm0TA15CkW267dOOv49Rrpwg36XHepA0yA==
+tina-graphql-gateway@^0.1.50:
+  version "0.1.50"
+  resolved "https://registry.yarnpkg.com/tina-graphql-gateway/-/tina-graphql-gateway-0.1.50.tgz#88a830ab400b43d269e28696d2b5ff2a4008b0f4"
+  integrity sha512-Q/EOgYbv4QqdWwuIh9TObEtTa13nrkLuAmFHmVq8Ft5q8Tszp1cxL+9VNfsKCnmpSq+S5jhT6P7TnUaAH/y5xw==
   dependencies:
     "@forestryio/graphql-helpers" "0.0.16"
     "@graphql-codegen/core" "^1.15.4"
@@ -12311,7 +12311,8 @@ tina-graphql-gateway@^0.1.48:
     codemirror "^5.55.0"
     cors "^2.8.5"
     crypto-js "^4.0.0"
-    final-form "4.20.1"
+    final-form "^4.20.1"
+    final-form-arrays "^3.0.2"
     graphql "^15.1.0"
     graphql-tag "^2.11.0"
     isomorphic-unfetch "^3.0.0"


### PR DESCRIPTION
Bump tina-graphql-gateway version to include blocks reordering fix.

fixes #11 