### PR TITLE
Fix: Better error message in DocumentRenderer

### DIFF
--- a/components/document-renderer.tsx
+++ b/components/document-renderer.tsx
@@ -8,16 +8,21 @@ import { PageRenderer } from "./page-renderer";
  * Each of these cases map to a `section` found in the `.tina/settings.yml`
  *
  */
+
 export const DocumentRenderer = (props: Tina.SectionDocumentUnion) => {
   switch (props.__typename) {
     case "Pages_Document":
       return <PageRenderer {...props.data} />;
     default:
-      return <NoData />;
+      return <NoRenderer typename={props.__typename} />;
   }
 };
 
-const NoData = () => {
-  console.error("Woops, this shouldn't be rendered!");
-  return <pre>No data</pre>;
+const NoRenderer = ({ typename }: { typename: String }) => {
+  return (
+    <pre>
+      [Error] Renderer for "{typename}" not found. Consider adding a Renderer
+      Component to DocumentRenderer?
+    </pre>
+  );
 };


### PR DESCRIPTION
Updates the error messaging when a Renderer is missing for a specific `__typename`.