### PR TITLE
Forestrygql 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-markdown": "^5.0.3",
     "styled-components": "^5.1.3",
     "styled-jsx": "^3.2.5",
-    "tina-graphql-gateway": "0.2.1",
+    "tina-graphql-gateway": "^0.2.3",
     "tinacms": "0.31.0",
     "typescript": "^3.8.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11878,10 +11878,10 @@ tina-graphql-gateway-cli@0.2.36:
     yo "^3.1.1"
     yup "^0.32.9"
 
-tina-graphql-gateway@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/tina-graphql-gateway/-/tina-graphql-gateway-0.2.1.tgz#8be414dc74380df40c4d3cfe86394c6823f94320"
-  integrity sha512-CQ2WGmvVXX8KjWll1Hb5UTIPfpJyrChLcfev2qGmWZ2ZphWkD53ci8uelHYe37VTa3yS4wJk5CqTfM9lWBqFSQ==
+tina-graphql-gateway@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/tina-graphql-gateway/-/tina-graphql-gateway-0.2.3.tgz#511839c88135af43c6d38baaf3cd39b7452760d9"
+  integrity sha512-fu6kfIYqjIe/ArqZLFS2Zvb0iazB5n1R48oZHnETiE9QBtAzmYPhteLgWXt2+9jSZ1lDLeIcq4kBeUVFOlZraQ==
   dependencies:
     "@forestryio/graphql-helpers" "0.0.19"
     "@graphql-codegen/core" "^1.15.4"


### PR DESCRIPTION
Branched off of https://github.com/tinacms/tina-cloud-starter/pull/39

Upgrade tina-graphql-gateway package to use updated /currentUser endpoint (required to login to tina cloud)