### PR TITLE
Data is stale after exiting edit mode

### DIFF
--- a/utils/editState.tsx
+++ b/utils/editState.tsx
@@ -38,7 +38,9 @@ export const EditProvider: React.FC = ({ children }) => {
     // set React state and localstorage
     setEditState(edit)
     setEditing(edit)
-    window.location.reload();
+if(process.env.NODE_ENV === 'development'){
+      window.location.reload();
+}
   }
   return (
     <EditContext.Provider value={{ edit, setEdit }}>

--- a/utils/editState.tsx
+++ b/utils/editState.tsx
@@ -38,6 +38,7 @@ export const EditProvider: React.FC = ({ children }) => {
     // set React state and localstorage
     setEditState(edit)
     setEditing(edit)
+    window.location.reload();
   }
   return (
     <EditContext.Provider value={{ edit, setEdit }}>

--- a/utils/editState.tsx
+++ b/utils/editState.tsx
@@ -39,6 +39,7 @@ export const EditProvider: React.FC = ({ children }) => {
     setEditState(edit)
     setEditing(edit)
 if(process.env.NODE_ENV === 'development'){
+      // Force Next.js to fetch fresh data from the file system when in dev mode
       window.location.reload();
 }
   }


### PR DESCRIPTION
Reload window when exiting edit mode since content would be stale from getStaticProps

cc @logan-anderson does this make sense?