### PR TITLE
47 - Hides Media Manager in Starter

### DIFF
--- a/components/tina-wrapper.tsx
+++ b/components/tina-wrapper.tsx
@@ -23,6 +23,13 @@ const TinaWrapper = (props) => {
     });
   }, []);
 
+  /** Disables the TinaCMS "Media Manager" */
+  cms.plugins.all("screen").forEach((plugin) => {
+    if (plugin.name === "Media Manager") {
+      cms.plugins.remove(plugin);
+    }
+  });
+
   return (
     <TinaCloudAuthWall cms={cms}>
       <Inner {...props} />


### PR DESCRIPTION
Uses `cms.plugins.all()` and `cms.plugins.remove()` to locate and remove the `Media Manager` plugin.  This removes the "Media Manager" option from the Tina Sidebar.

Closes #47 