### PR TITLE
Prototype handling env vars on the client side to lower initial deployment friction

### DIFF
--- a/components/tina-wrapper.tsx
+++ b/components/tina-wrapper.tsx
@@ -21,12 +21,17 @@ import { LoadingPage } from "./Spinner";
  * if you're on a route that starts with "/admin"
  */
 const TinaWrapper = (props) => {
+
+  // TODO: handle when localStorage is missing
+  const clientID = localStorage.getItem('tinaClientID') ? localStorage.getItem('tinaClientID') : process.env.NEXT_PUBLIC_TINA_CLIENT_ID;
+  const organization = localStorage.getItem('tinaOrganization') ? localStorage.getItem('tinaOrganization') : process.env.NEXT_PUBLIC_ORGANIZATION_NAME;
+  
   return (
     <TinaCloudProvider
-      clientId={process.env.NEXT_PUBLIC_TINA_CLIENT_ID}
+      clientId={clientID}
       branch="main"
       isLocalClient={Boolean(Number(process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT))}
-      organization={process.env.NEXT_PUBLIC_ORGANIZATION_NAME}
+      organization={organization}
     >
       {props.query ? <Inner {...props} /> : props.children(props)}
     </TinaCloudProvider>

--- a/components/variables.tsx
+++ b/components/variables.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from "react";
+
+export const EnvVarForm = () => {
+  const [clientID, setClientID] = useState(null);
+  const [organization, setOrganization] = useState(null);
+
+  const updateClientID = (e) => {
+    setClientID(e.target.value);
+    localStorage.setItem('tinaClientID', e.target.value);
+  };
+
+  const updateOrganization = (e) => {
+    setOrganization(e.target.value);
+    localStorage.setItem('tinaOrganization', e.target.value);
+  };
+
+  useEffect(() => {
+    setClientID(localStorage.getItem('tinaClientID') ? localStorage.getItem('tinaClientID') : process.env.NEXT_PUBLIC_TINA_CLIENT_ID);
+    setOrganization(localStorage.getItem('tinaOrganization') ? localStorage.getItem('tinaOrganization') : process.env.NEXT_PUBLIC_ORGANIZATION_NAME);
+  });
+
+  // conditionally render, need a way to hide
+    return (
+      <div>
+        <h2>Tina Environment Variables</h2>
+        <p>Description about needing env vars, where to get them in the dashboard ...NEXT_PUBLIC_TINA_CLIENT_ID & NEXT_PUBLIC_ORGANIZATION_NAME</p>
+
+        <div>
+          <label>Tina Client ID</label>
+          <input type="text" value={clientID} onChange={updateClientID} size={50}/>
+        </div>
+
+        <div>
+          <label>Tina Organization</label>
+          <input type="text" value={organization} onChange={updateOrganization} size={50}/>
+        </div>
+      </div>
+    )
+
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,8 @@ import { Wrapper } from "../components/helper-components";
 import type { MarketingPages_Document } from "../.tina/__generated__/types";
 import { LocalClient } from "tina-graphql-gateway";
 
+import { EnvVarForm } from "../components/variables";
+
 export type AsyncReturnType<T extends (...args: any) => Promise<any>> =
   T extends (...args: any) => Promise<infer R> ? R : any;
 
@@ -13,6 +15,7 @@ export default function HomePage(
     <>
       <Wrapper data={props.data.getMarketingPagesDocument.data}>
         <LandingPage {...props.data.getMarketingPagesDocument.data} />
+        <EnvVarForm />
       </Wrapper>
     </>
   );


### PR DESCRIPTION
I believe the environment variables needed to use the Tina client don't have to be kept secret. I'm experimenting with prompting for the variables on the client side so that folks can quickly deploy the starter to Vercel for example.

I think the flow would be like:

1. Deploy with the Vercel button: [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Ftinacms%2Ftina-cloud-starter)

2. The developer can see the starter is deployed and is notified that the environment variables are missing.

3. They go to the Tina dashboard to create the App. Since the site is deployed, the user now has the desired site_url.

4. The developer can enter the environment variables client side to start editing without redeploying the site

5. The developer sets up the environment variables with the Vercel site deployment after seeing things in action