### PR TITLE
chore: Adds documentCreatorCallback

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -19,6 +19,23 @@ const App = ({ Component, pageProps }) => {
             clientId={NEXT_PUBLIC_TINA_CLIENT_ID}
             isLocalClient={Boolean(Number(NEXT_PUBLIC_USE_LOCAL_CLIENT))}
             mediaStore={TinaCloudCloudinaryMediaStore}
+            documentCreatorCallback={{
+              /**
+               * After a new document is created, redirect to its location
+               */
+              onNewDocument: ({ collection: { slug }, breadcrumbs }) => {
+                const relativeUrl = `/${slug}/${breadcrumbs.join("/")}`;
+                return (window.location.href = relativeUrl);
+              },
+              /**
+               * Only allows documents to be created to the `Blog Posts` Collection
+               */
+              filterCollections: (options) => {
+                return options.filter(
+                  (option) => option.label === "Blog Posts"
+                );
+              },
+            }}
             {...pageProps}
           >
             {(livePageProps) => (


### PR DESCRIPTION
Adds `onNewDocument()` and `filterCollections()` via `documentCreatorCallback` for handling when a new document is created (redirecting to the newly-created document) and limiting the Collection choices to just `Blog Posts`.

Closes #106 

Closes https://github.com/tinacms/tinacms/issues/1902