### PR TITLE
Fix/exit edit mode

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -11,5 +11,3 @@ NEXT_PUBLIC_USE_LOCAL_CLIENT=1
 
 # 0 means do not show the edit button and 1 means show the edit button (the button is always shown when in edit mode)
 # If the button is not present you can go to /admin to enter edit mode
-
-NEXT_PUBLIC_SHOW_EDIT_BTN=1

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "yarn tinacms server:start -c \"next dev\" --experimental",
-    "build": "yarn tinacms server:start -c \"next build\" --experimental",
-    "start": "yarn tinacms server:start -c \"next start\" --experimental",
-    "export": "yarn build && next export --experimental"
+    "dev": "yarn tinacms server:start -c \"next dev\"",
+    "build": "yarn tinacms server:start -c \"next build\"",
+    "start": "yarn tinacms server:start -c \"next start\"",
+    "export": "yarn build && next export"
   },
   "devDependencies": {
     "@tinacms/cli": "^0.0.0-2021620215324",

--- a/pages/exit-admin.tsx
+++ b/pages/exit-admin.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import { Container } from "../components/container";
+import { Section } from "../components/section";
+import { Layout } from "../components/layout";
+import { useEditState } from "tinacms/dist/edit-state";
+
+const GoToEditPage: React.FC = () => {
+  const { setEdit } = useEditState();
+  const router = useRouter();
+  useEffect(() => {
+    setEdit(false);
+    router.back();
+  }, []);
+  return (
+    <Layout>
+      <Section className="flex-1">
+        <Container size="large prose prose-xl">
+          <h2>Exiting edit mode...</h2>
+        </Container>
+      </Section>
+    </Layout>
+  );
+};
+
+export default GoToEditPage;


### PR DESCRIPTION
Currently there is no way to exit edit mode. This PR adds a way to do that. I will make a PR to do guide to update it as well.

To exit edit mode, visit  the /exit-admin route. 