### PR TITLE
add constraints on image size

### DIFF
--- a/components/post.tsx
+++ b/components/post.tsx
@@ -59,10 +59,11 @@ export const Post = ({ data }) => {
         </div>
       </Container>
       {data.heroImg && (
-        <div className="">
+        <div className="px-6">
           <img
             src={data.heroImg}
-            className="mb-14 block h-auto max-w-4xl lg:max-w-6xl mx-auto"
+            className="mb-14 block h-auto w-full max-w-4xl lg:max-w-6xl mx-auto object-cover rounded-md"
+            style={{ maxHeight: "70vh" }}
           />
         </div>
       )}

--- a/components/post.tsx
+++ b/components/post.tsx
@@ -59,11 +59,11 @@ export const Post = ({ data }) => {
         </div>
       </Container>
       {data.heroImg && (
-        <div className="px-6">
+        <div className="px-6 max-w-4xl lg:max-w-6xl flex justify-center mx-auto">
           <img
             src={data.heroImg}
-            className="mb-14 block h-auto w-full max-w-4xl lg:max-w-6xl mx-auto object-cover rounded-md"
-            style={{ maxHeight: "70vh" }}
+            className="mb-14 block h-auto max-w-full mx-auto object-cover rounded-md"
+            style={{ maxHeight: "80vh" }}
           />
         </div>
       )}


### PR DESCRIPTION
On mobile the image wasn't displaying correctly and especially tall images looked quite bad. This limits the image size without stretching it, but it may get cropped to ensure it doesn't take up too much of the page.