### PR TITLE
fix blog body saving issue

### DIFF
--- a/.tina/__generated__/_graphql.json
+++ b/.tina/__generated__/_graphql.json
@@ -1516,7 +1516,7 @@
           "kind": "FieldDefinition",
           "name": {
             "kind": "Name",
-            "value": "_body"
+            "value": "body"
           },
           "arguments": [],
           "type": {
@@ -3973,7 +3973,7 @@
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "_body"
+            "value": "body"
           },
           "type": {
             "kind": "NamedType",

--- a/.tina/__generated__/_schema.json
+++ b/.tina/__generated__/_schema.json
@@ -53,11 +53,11 @@
           "ui": {
             "component": "markdown"
           },
-          "name": "_body",
+          "name": "body",
           "isBody": true,
           "namespace": [
             "posts",
-            "_body"
+            "body"
           ]
         }
       ],

--- a/.tina/__generated__/config/schema.json
+++ b/.tina/__generated__/config/schema.json
@@ -37,7 +37,7 @@
           "ui": {
             "component": "markdown"
           },
-          "name": "_body",
+          "name": "body",
           "isBody": true
         }
       ]

--- a/.tina/__generated__/schema.gql
+++ b/.tina/__generated__/schema.gql
@@ -87,7 +87,7 @@ type Posts {
   author: PostsAuthorDocument
   heroImg: String
   excerpt: String
-  _body: String
+  body: String
 }
 
 type PostsDocument implements Node & Document {
@@ -293,7 +293,7 @@ input PostsMutation {
   author: String
   heroImg: String
   excerpt: String
-  _body: String
+  body: String
 }
 
 input GlobalHeaderIconMutation {

--- a/.tina/__generated__/types.ts
+++ b/.tina/__generated__/types.ts
@@ -193,7 +193,7 @@ export type Posts = {
   author?: Maybe<PostsAuthorDocument>;
   heroImg?: Maybe<Scalars['String']>;
   excerpt?: Maybe<Scalars['String']>;
-  _body?: Maybe<Scalars['String']>;
+  body?: Maybe<Scalars['String']>;
 };
 
 export type PostsDocument = Node & Document & {
@@ -467,7 +467,7 @@ export type PostsMutation = {
   author?: Maybe<Scalars['String']>;
   heroImg?: Maybe<Scalars['String']>;
   excerpt?: Maybe<Scalars['String']>;
-  _body?: Maybe<Scalars['String']>;
+  body?: Maybe<Scalars['String']>;
 };
 
 export type GlobalHeaderIconMutation = {

--- a/.tina/schema.ts
+++ b/.tina/schema.ts
@@ -417,7 +417,7 @@ export default defineSchema({
           ui: {
             component: "markdown",
           },
-          name: "_body",
+          name: "body",
           isBody: true,
         },
       ],

--- a/components/post.tsx
+++ b/components/post.tsx
@@ -68,7 +68,7 @@ export const Post = ({ data }) => {
       )}
       <Container className={`flex-1 max-w-4xl pt-4`} size="large">
         <div className="prose dark:prose-dark  w-full max-w-none">
-          <Markdown>{data._body}</Markdown>
+          <Markdown>{data.body}</Markdown>
         </div>
       </Container>
     </Section>

--- a/pages/posts/[filename].tsx
+++ b/pages/posts/[filename].tsx
@@ -27,7 +27,7 @@ export const getStaticProps = async ({ params }) => {
               }
             }
             heroImg
-            _body
+            body
           }
         }
       }


### PR DESCRIPTION
The blog markdown body was saving to the frontmatter due to a bug with Tina, so I've renamed the body field from `_body` to just `body` to resolve the issue.