### PR TITLE
Updates NoFormsPlaceholder Link

### DIFF
--- a/components/placeholder.tsx
+++ b/components/placeholder.tsx
@@ -14,10 +14,7 @@ export const Placeholder = () => (
       so you can start editing.
     </p>
     <p>
-      <a
-        href="https://tina.io/guides/tina-cloud/add-tinacms-to-existing-site/content-modelling/"
-        target="_blank"
-      >
+      <a href="https://tina.io/docs/schema/" target="_blank">
         <span>📖</span> Content Modelling
       </a>
     </p>

--- a/components/placeholder.tsx
+++ b/components/placeholder.tsx
@@ -14,8 +14,11 @@ export const Placeholder = () => (
       so you can start editing.
     </p>
     <p>
-      <a href="https://tina.io/docs/tina-cloud/client/" target="_blank">
-        <span>📖</span> Client Setup Guide
+      <a
+        href="https://tina.io/guides/tina-cloud/add-tinacms-to-existing-site/content-modelling/"
+        target="_blank"
+      >
+        <span>📖</span> Content Modelling
       </a>
     </p>
   </div>


### PR DESCRIPTION
Sister PR to https://github.com/tinacms/tinacms/pull/2028
Updates the link in the `NoFormsPlaceholder` to point to the Content Modelling page on tina.io:
https://tina.io/docs/schema/

Related to https://github.com/tinacms/tinacms/issues/2007