### PR TITLE
Handle falsey date values in Posts

### DIFF
--- a/components/post.tsx
+++ b/components/post.tsx
@@ -20,8 +20,14 @@ export const Post = ({ data }) => {
     yellow:
       "from-yellow-400 to-yellow-500 dark:from-yellow-300 dark:to-yellow-500",
   };
-  const date = new Date(data.date);
-  const formattedDate = format(date, "MMM dd, yyyy");
+  /**
+   * Formats date field value to be more readable.
+   */
+  let formattedDate
+  if (data?.date !== null) {
+    const date = data.date ? new Date(data.date) : '';
+    formattedDate = date ? format(date, "MMM dd, yyyy") : date;
+  }
 
   return (
     <Section className="flex-1">

--- a/components/posts.tsx
+++ b/components/posts.tsx
@@ -22,8 +22,15 @@ export const Posts = ({ data }) => {
     <>
       {data.map((postData) => {
         const post = postData.node;
-        const date = new Date(post?.values?.date) ?? new Date();
-        const formattedDate = format(date, "MMM dd, yyyy");
+        /**
+         * Formats date field value to be more readable.
+         */
+        let formattedDate
+        if (post?.values.date !== null) {
+          const date = post.values.date ? new Date(post?.values?.date) : '';
+          formattedDate = date ? format(date, "MMM dd, yyyy") : date;
+        }
+
         return (
           <Link
             key={post.sys.filename}
@@ -56,7 +63,7 @@ export const Posts = ({ data }) => {
                   />
                 </div>
                 <p className="text-sm font-medium text-gray-600 group-hover:text-gray-800 dark:text-gray-200 dark:group-hover:text-white">
-                  {post.data.author.data.name}
+                  {post.data.author?.data.name}
                 </p>
                 <span className="font-bold text-gray-200 dark:text-gray-500 mx-2">
                   —


### PR DESCRIPTION
This PR adds in some defensive coding measures in the event an invalid date is present in the form.

We are handling this primarily on the backend; however, this can manifest on the frontend when creating a new document, and attempting to formatting a null value will cause the app to break.

