### PR TITLE
Update to latest Tina dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "export": "yarn build && next export"
   },
   "devDependencies": {
-    "@tinacms/cli": "^0.55.1",
+    "@tinacms/cli": "^0.55.2",
     "@types/js-cookie": "^2.2.6",
     "@types/node": "^13.13.1",
     "@types/react": "^16.9.43",
@@ -23,20 +23,20 @@
   "dependencies": {
     "@headlessui/react": "^1.3.0",
     "@tailwindcss/typography": "^0.4.1",
-    "@tinacms/auth": "^0.50.0",
+    "@tinacms/auth": "^0.50.1",
     "date-fns": "^2.23.0",
     "next": "10.0.5",
     "next-svgr": "^0.0.2",
-    "next-tinacms-cloudinary": "^3.2.3",
+    "next-tinacms-cloudinary": "^3.2.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-icons": "^4.2.0",
     "react-is": "^17.0.2",
     "react-markdown": "^5.0.3",
-    "react-tinacms-editor": "^0.51.6",
+    "react-tinacms-editor": "^0.51.7",
     "styled-components": "^5.1.3",
     "styled-jsx": "^3.2.5",
-    "tinacms": "^0.55.0",
+    "tinacms": "^0.55.1",
     "typescript": "^3.8.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1994,20 +1994,20 @@
     lodash.merge "^4.6.2"
     lodash.uniq "^4.5.0"
 
-"@tinacms/auth@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@tinacms/auth/-/auth-0.50.0.tgz#07b05cc4f79d7c442269cb371df29297078a3174"
-  integrity sha512-C4LQALN+eJqyrnEVmgB2Ee/kpZWdIGPZ2CuAdA0VHtOiuUovBasH3ut4/WjcgwJz9itzAT9b51raSMgZ9XUgXw==
+"@tinacms/auth@^0.50.1":
+  version "0.50.1"
+  resolved "https://registry.yarnpkg.com/@tinacms/auth/-/auth-0.50.1.tgz#47ee8fd6fb235de07d30802076391a9221f9270e"
+  integrity sha512-lXlH2Y+ffRAHejvw2TGUU+LO+R5MBYcaxb7uE9dr5jgVURCqRRVLiuwSz4o8WgfwUb5cni+wFHCZVHjqT3e0kQ==
 
-"@tinacms/cli@^0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@tinacms/cli/-/cli-0.55.1.tgz#ed6154ba1cfe847ddfd97550c44f0854205ab973"
-  integrity sha512-Ol6Rjz+QnrSVGdr8ZBmqRW8axwLTMeMOXeUkV82RNxh5VKNeIdSYFJHZC04IOh0upc1kM14SaOrukmJVeWNgqw==
+"@tinacms/cli@^0.55.2":
+  version "0.55.2"
+  resolved "https://registry.yarnpkg.com/@tinacms/cli/-/cli-0.55.2.tgz#c3688311f668351e0e94837df82f944cc545ca99"
+  integrity sha512-+2DUilCpSTQoAk7U6/VEGegnXSNm98QBx2HhfE+k4xOuVarqxAv1r4fEJA8WAHMy+2Szmd63fdGhWMFoRaZvwQ==
   dependencies:
     "@graphql-codegen/core" "^1.17.0"
     "@graphql-codegen/typescript" "^1.17.0"
     "@graphql-codegen/typescript-operations" "^1.17.0"
-    "@tinacms/graphql" "0.54.2"
+    "@tinacms/graphql" "0.54.3"
     ajv "^6.12.3"
     altair-express-middleware "4.0.6"
     axios "0.19.0"
@@ -2032,14 +2032,15 @@
     typescript "^4.3.5"
     yup "^0.32.9"
 
-"@tinacms/graphql@0.54.2":
-  version "0.54.2"
-  resolved "https://registry.yarnpkg.com/@tinacms/graphql/-/graphql-0.54.2.tgz#47317bb4a8367cb17658d782db1dbb4eec303615"
-  integrity sha512-sihEq40sz3T6k5AxuXmogBdOvcgtQqmsAD/M1o4UUsQ8a8WvV2SM/xnbuzA9BZ1SYMGalEkK4LHWVHSCtiQ2NA==
+"@tinacms/graphql@0.54.3":
+  version "0.54.3"
+  resolved "https://registry.yarnpkg.com/@tinacms/graphql/-/graphql-0.54.3.tgz#6d735fe6a57d69e63b29e8a501cc56ca6f31e3e3"
+  integrity sha512-131JgETQd4nypPQ9RJi96HuXwRbtnO6lWsZLyS0muHD4b7sqhnEOG6kdZVBa/yJQTWbMDGLYvcWHsRoz2L6VPQ==
   dependencies:
     "@octokit/auth-app" "^2.6.0"
     "@octokit/graphql" "^4.5.6"
     "@octokit/rest" "18.0.6"
+    "@types/aws-sdk" "^2.7.0"
     aws-sdk "^2.930.0"
     body-parser "^1.19.0"
     cors "^2.8.5"
@@ -2070,12 +2071,16 @@
     ws "^7.3.1"
     yup "^0.32.9"
 
-"@tinacms/toolkit@0.52.2":
-  version "0.52.2"
-  resolved "https://registry.yarnpkg.com/@tinacms/toolkit/-/toolkit-0.52.2.tgz#d7c38ffbc54499ac9b9aa8a4919b4367cb77f4e9"
-  integrity sha512-qDrjQ/DOtH37I7sXf2npa+gzcCe6+B3jNWW4+JEJySex1tu8Yo1ZiALEmbYRjX8BJxEXzHu5U1Tasts6nfOuWg==
+"@tinacms/toolkit@0.52.3":
+  version "0.52.3"
+  resolved "https://registry.yarnpkg.com/@tinacms/toolkit/-/toolkit-0.52.3.tgz#bfcaa3e44d8475f681520614ad95b46a90dc4303"
+  integrity sha512-TdC80vK347WWTkHEOlL0l/ZanLz7fyXAmZ5pamIFRU7FROA1D4hiXCVfU6TGR6GJNctJWgKuMXpd+Rq2tQwplg==
   dependencies:
     "@sambego/storybook-styles" "^1.0.0"
+    "@types/atob" "^2.1.2"
+    "@types/cors" "^2.8.12"
+    "@types/express" "^4.17.13"
+    "@types/multer" "^1.4.7"
     "@types/prop-types" "^15.7.4"
     atob "2.1.2"
     color-string "^1.5.3"
@@ -2095,12 +2100,64 @@
     react-final-form "^6.3.0"
     simple-git "1.126.0"
     tsup "^3.7.0"
+    typescript "^4.3.5"
     webfontloader "1.6.28"
+
+"@types/atob@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@types/atob/-/atob-2.1.2.tgz#157eb0cc46264a8c55f2273a836c7a1a644fb820"
+  integrity sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==
+
+"@types/aws-sdk@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@types/aws-sdk/-/aws-sdk-2.7.0.tgz#83588b3d14ebdca1d4ce5e023387577568ce82f3"
+  integrity sha1-g1iLPRTr3KHUzl4CM4dXdWjOgvM=
+  dependencies:
+    aws-sdk "*"
+
+"@types/body-parser@*":
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.1.tgz#0c0174c42a7d017b818303d4b5d969cb0b75929c"
+  integrity sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cors@^2.8.12":
+  version "2.8.12"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
+  integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
 
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/express-serve-static-core@^4.17.18":
+  version "4.17.24"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz#ea41f93bf7e0d59cd5a76665068ed6aab6815c07"
+  integrity sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@*", "@types/express@^4.17.13":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
+  integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
 
 "@types/hoist-non-react-statics@*", "@types/hoist-non-react-statics@^3.3.0":
   version "3.3.1"
@@ -2163,6 +2220,18 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/mime@^1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
+  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+
+"@types/multer@^1.4.7":
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.4.7.tgz#89cf03547c28c7bbcc726f029e2a76a7232cc79e"
+  integrity sha512-/SNsDidUFCvqqcWDwxv2feww/yqhNeTRL5CVoL3jU4Goc4kKEL10T7Eye65ZqPNi4HRx8sAEX59pV1aEH7drNA==
+  dependencies:
+    "@types/express" "*"
+
 "@types/node@*":
   version "15.12.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
@@ -2197,6 +2266,16 @@
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
+
+"@types/qs@*":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/range-parser@*":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
+  integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
 "@types/react-redux@^7.1.16":
   version "7.1.16"
@@ -2237,6 +2316,14 @@
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
+
+"@types/serve-static@*":
+  version "1.13.10"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
+  integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
 
 "@types/styled-components@^5.1.3":
   version "5.1.10"
@@ -2918,6 +3005,21 @@ aws-appsync-subscription-link@^3.0.3:
     aws-appsync-auth-link "^3.0.5"
     debug "2.6.9"
     url "^0.11.0"
+
+aws-sdk@*:
+  version "2.976.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.976.0.tgz#1e9d0d359698876eaa952c7c6223eac4c354ae2e"
+  integrity sha512-LWVh3nko6yGDfGcDW9nIClaukthkTueq7I/dXVNv4g9kuy2VOl5fVTPMACgTibWINAM29wZCM+gVQSSZu/Veow==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
 
 aws-sdk@^2.814.0, aws-sdk@^2.930.0:
   version "2.952.0"
@@ -7379,10 +7481,10 @@ next-tick@~1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-next-tinacms-cloudinary@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/next-tinacms-cloudinary/-/next-tinacms-cloudinary-3.2.3.tgz#5224582e26860b0e32646a9b276e4a6e0fa8ebf8"
-  integrity sha512-z5588aevbXI8YVrhsdBdg4UVQjEi6G91NJaSdJ+IqczhiFuB44A2FoaHvfBxMt4ASQULcWAw+4FAZ13bHpmGiw==
+next-tinacms-cloudinary@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/next-tinacms-cloudinary/-/next-tinacms-cloudinary-3.2.4.tgz#bc67c7fd0351ee5c620e2520d4bb516645350ffb"
+  integrity sha512-trXjZHLY9GNov0dW9lRg8SU9b27wptSjvA+6arZ6KMvePQeQ8bw0glUdV4K3zsQ3aU31nXAvIJq6RNERVptl1g==
   dependencies:
     cloudinary "^1.25.2"
     multer "^1.4.2"
@@ -8991,12 +9093,12 @@ react-refresh@0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-tinacms-editor@^0.51.6:
-  version "0.51.6"
-  resolved "https://registry.yarnpkg.com/react-tinacms-editor/-/react-tinacms-editor-0.51.6.tgz#179e07674d2ad317392818f0624dfb86098dd778"
-  integrity sha512-/Nsk9N6PMQGvyjC7ndk43uFRj5u1YZSUnn3ZBggQevUyz5qT6WZD8Nr5Y+kRFtxQu+UeFnTkXO6s1wQYKKZwfQ==
+react-tinacms-editor@^0.51.7:
+  version "0.51.7"
+  resolved "https://registry.yarnpkg.com/react-tinacms-editor/-/react-tinacms-editor-0.51.7.tgz#7f4dfebbdf2e53cec0fd9383209dfbb70b03b5c9"
+  integrity sha512-orGf29fffZVuGmRBW52LVD7nz+Z/Rg3NqfuTJzXSoUfKs4KJ+7LdunFFJ6fBMLqVXjzv3qQGotwNPC83EMvCtQ==
   dependencies:
-    "@tinacms/toolkit" "0.52.2"
+    "@tinacms/toolkit" "0.52.3"
     codemirror "^5.42.2"
     lodash.debounce "^4.0.8"
     lodash.get "^4.4.2"
@@ -10506,15 +10608,15 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tinacms@^0.55.0:
-  version "0.55.0"
-  resolved "https://registry.yarnpkg.com/tinacms/-/tinacms-0.55.0.tgz#b5141c3631d27dc192879539609d6e3e246a5dc8"
-  integrity sha512-Rn0+AWi+2d7JJV2FdpI6erHmg8Nq091k5mTBXpFAMQ0UgWHNnyZfZ/O4PUrwglhawkto1gDhMc5hX3O5HRvFIA==
+tinacms@^0.55.1:
+  version "0.55.1"
+  resolved "https://registry.yarnpkg.com/tinacms/-/tinacms-0.55.1.tgz#d5010fbd1995e17aa05bcaeee5e6bd20f3d47ac8"
+  integrity sha512-NuWB9CteGKeiwS4KjSbCiMa/iu89b0rQHtYDOS80vHkIA4SCdweC1MubZvMsZ2amLEkOzQxJ8rrXdyzlcx5MnQ==
   dependencies:
     "@graphql-codegen/core" "^1.15.4"
     "@graphql-codegen/typescript" "^1.15.4"
     "@graphql-codegen/typescript-operations" "^1.15.4"
-    "@tinacms/toolkit" "0.52.2"
+    "@tinacms/toolkit" "0.52.3"
     "@xstate/react" "^1.1.0"
     codemirror "^5.55.0"
     cors "^2.8.5"


### PR DESCRIPTION
This uses the latest builds, which were mostly a DX concern for the tina monorepo. There were a lot of changes though so to anyone who reviews this it might be best to pull it down and give the things a look over. All seems to be ok from what I can see