### PR TITLE
fix: ignore .env.developement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .DS_Store
 .env
 .env.local
+.env.development
 
 # debug
 npm-debug.log*


### PR DESCRIPTION
Avoid pushing out credentials in your repository.

props @jhuggett