### PR TITLE
Hide edit btn env

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -5,3 +5,4 @@ NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=<Get this from your Cloudinary account>
 NEXT_PUBLIC_CLOUDINARY_API_KEY=<Get this from your Cloudinary account>
 CLOUDINARY_API_SECRET=<Get this from your Cloudinary account>
 
+NEXT_PUBLIC_HIDE_EDIT_BUTTON=0 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,12 +8,14 @@ import { TinaCloudCloudinaryMediaStore } from "next-tinacms-cloudinary";
 const NEXT_PUBLIC_TINA_CLIENT_ID = process.env.NEXT_PUBLIC_TINA_CLIENT_ID;
 const NEXT_PUBLIC_USE_LOCAL_CLIENT =
   process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT || 0;
+const NEXT_PUBLIC_HIDE_EDIT_BUTTON =
+  process.env.NEXT_PUBLIC_HIDE_EDIT_BUTTON || 0;
 
 const App = ({ Component, pageProps }) => {
   return (
     <>
       <TinaEditProvider
-        showEditButton={false}
+        showEditButton={!Boolean(Number(NEXT_PUBLIC_HIDE_EDIT_BUTTON))}
         editMode={
           <TinaCMS
             branch="main"


### PR DESCRIPTION
I'm not sure that it's obvious how to edit, once you land on the starter. 
We hid the button by default, because we didn't want it to show up on our hosted tina-cloud-starter, but I think the user needs that extra help to know what to do when they land on the starter for the first time. 

- [x] Add env to our hosted config, so that the edit-button doesn't show for our hosted starter