### PR TITLE
remove distractions from admin page

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -15,7 +15,7 @@ const App = ({ Component, pageProps }) => {
   return (
     <>
       <TinaEditProvider
-        showEditButton={!Boolean(Number(NEXT_PUBLIC_HIDE_EDIT_BUTTON))}
+        showEditButton={!Boolean(Number(NEXT_PUBLIC_HIDE_EDIT_BUTTON)) && pageProps.query}
         editMode={
           <TinaCMS
             branch="main"

--- a/pages/admin/[[...slug]].tsx
+++ b/pages/admin/[[...slug]].tsx
@@ -96,17 +96,6 @@ const GoToEditPage: React.FC = () => {
                   linkButtonColorClasses[theme.color]
                 }`}
                 onClick={() => {
-                  router.push("/");
-                }}
-              >
-                <BiHomeAlt className={`mr-1.5 w-6 h-6 opacity-80`} /> Go to the
-                home page
-              </button>
-              <button
-                className={`group inline-flex items-center font-semibold text-lg transition duration-150 ease-out ${
-                  linkButtonColorClasses[theme.color]
-                }`}
-                onClick={() => {
                   router.back();
                 }}
               >


### PR DESCRIPTION
Remove "Edit with Tina" and "homepage" (when not logged in) links from admin page
<img width="981" alt="Screen Shot 2021-11-29 at 12 23 19 PM" src="https://user-images.githubusercontent.com/3323181/143904734-ad3dae72-6647-4cbf-9c38-f195b2a9cf22.png">

I think this should cover some of @scottgallant 's friction https://www.loom.com/share/40a66f0cfc974a85913691cd0d10ce59

fixes #185