### PR TITLE
Add back NEXT_PUBLIC_HIDE_EDIT_BUTTON to toggle

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,11 +23,14 @@ const apiURL =
     ? "http://localhost:4001/graphql"
     : `https://content.tinajs.io/content/${process.env.NEXT_PUBLIC_TINA_CLIENT_ID}/github/${branch}`;
 
+const NEXT_PUBLIC_HIDE_EDIT_BUTTON =
+  process.env.NEXT_PUBLIC_HIDE_EDIT_BUTTON || true;
+
 const App = ({ Component, pageProps }) => {
   return (
     <>
       <TinaEditProvider
-        showEditButton={true}
+        showEditButton={{Boolean(Number(NEXT_PUBLIC_HIDE_EDIT_BUTTON))}}
         editMode={
           <TinaCMS
             apiURL={apiURL}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -30,7 +30,7 @@ const App = ({ Component, pageProps }) => {
   return (
     <>
       <TinaEditProvider
-        showEditButton={{Boolean(Number(NEXT_PUBLIC_HIDE_EDIT_BUTTON))}}
+        showEditButton={Boolean(Number(NEXT_PUBLIC_HIDE_EDIT_BUTTON))}
         editMode={
           <TinaCMS
             apiURL={apiURL}


### PR DESCRIPTION
We claim that you can turn off our HIDE_EDIT_BUTTON with a .env this is not true as we have it hard coded.

This fix will allow that. If we don't want this we should update our MD and files to reflect this. 