### PR TITLE
Icon cleanup & fixes

### DIFF
--- a/components/blocks/features.tsx
+++ b/components/blocks/features.tsx
@@ -16,7 +16,7 @@ export const Feature = ({ featuresColor, data, tinaField }) => {
         <Icon
           tinaField={`${tinaField}.icon`}
           parentColor={featuresColor}
-          data={data.icon}
+          data={{ size: "large", ...data.icon }}
         />
       )}
       {data.title && (

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -56,7 +56,6 @@ export const Footer = ({ data, icon, rawData }) => {
                   name: icon.name,
                   color: data.color === "primary" ? "primary" : icon.color,
                   style: icon.style,
-                  size: "custom",
                 }}
                 className="inline-block h-10 w-auto group-hover:text-orange-500"
               />

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -55,6 +55,7 @@ export const Footer = ({ data, icon, rawData }) => {
                 data={{
                   name: icon.name,
                   color: data.color === "primary" ? "primary" : icon.color,
+                  style: icon.style,
                   size: "custom",
                 }}
                 className="inline-block h-10 w-auto group-hover:text-orange-500"

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -43,11 +43,11 @@ export const Header = ({ data }) => {
   // If we're on an admin path, other links should also link to their admin paths
   const [prefix, setPrefix] = React.useState("");
   const [windowUrl, setUrl] = React.useState("");
-  const isBrowser = typeof window !== "undefined"
-  const hasUrl = isBrowser ? window.location.href : '';
+  const isBrowser = typeof window !== "undefined";
+  const hasUrl = isBrowser ? window.location.href : "";
 
   React.useEffect(() => {
-      setUrl(hasUrl);
+    setUrl(hasUrl);
   }, [hasUrl]);
 
   React.useEffect(() => {
@@ -68,6 +68,7 @@ export const Header = ({ data }) => {
                   data={{
                     name: data.icon.name,
                     color: data.icon.color,
+                    style: data.icon.style,
                     size: "custom",
                   }}
                   className="inline-block h-auto w-10 mr-1"

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -69,7 +69,6 @@ export const Header = ({ data }) => {
                     name: data.icon.name,
                     color: data.icon.color,
                     style: data.icon.style,
-                    size: "custom",
                   }}
                   className="inline-block h-auto w-10 mr-1"
                 />{" "}

--- a/components/icon.tsx
+++ b/components/icon.tsx
@@ -88,6 +88,36 @@ const heroIconOptions = {
   tina: TinaIconSvg,
 };
 
+const iconCircleColorClass = {
+  blue: "bg-blue-400 dark:bg-blue-500 text-blue-50",
+  teal: "bg-teal-400 dark:bg-teal-500 text-teal-50",
+  green: "bg-green-400 dark:bg-green-500 text-green-50",
+  red: "bg-red-400 dark:bg-red-500 text-red-50",
+  pink: "bg-pink-400 dark:bg-pink-500 text-pink-50",
+  purple: "bg-purple-400 dark:bg-purple-500 text-purple-50",
+  orange: "bg-orange-400 dark:bg-orange-500 text-orange-50",
+  yellow: "bg-yellow-400 dark:bg-yellow-500 text-yellow-50",
+};
+
+const iconColorClass = {
+  blue: "text-blue-400",
+  teal: "text-teal-400",
+  green: "text-green-400",
+  red: "text-red-400",
+  pink: "text-pink-400",
+  purple: "text-purple-400",
+  orange: "text-orange-400",
+  yellow: "text-yellow-400",
+  white: "text-white opacity-80",
+};
+
+const iconSizeClass = {
+  small: "w-8 h-8",
+  medium: "w-12 h-12",
+  large: "w-14 h-14",
+  custom: "",
+};
+
 export const Icon = ({
   data,
   parentColor = "",
@@ -95,43 +125,19 @@ export const Icon = ({
   tinaField = "",
 }) => {
   const theme = React.useContext(ThemeContext);
-  const IconSVG = React.useMemo(() => {
-    const iconOptions =
-      theme.icon === "boxicon" ? biIconOptions : heroIconOptions;
-    if (!data.name || data.name === "" || !iconOptions[data.name]) {
-      return randomProperty(iconOptions);
-    } else {
-      return iconOptions[data.name];
-    }
-  }, [data.name, theme.icon]);
+
+  const iconOptions =
+    theme.icon === "boxicon" ? biIconOptions : heroIconOptions;
+
+  const IconSVG =
+    !data.name || !iconOptions[data.name]
+      ? Object.keys(iconOptions)[0]
+      : iconOptions[data.name];
 
   const iconSize = data.size ? data.size : "large";
 
   /* Full class strings are required for Tailwind's just-in-time mode,
      I would love a better solution that doesn't require so much repetition */
-
-  const iconCircleColorClass = {
-    blue: "bg-blue-400 dark:bg-blue-500 text-blue-50",
-    teal: "bg-teal-400 dark:bg-teal-500 text-teal-50",
-    green: "bg-green-400 dark:bg-green-500 text-green-50",
-    red: "bg-red-400 dark:bg-red-500 text-red-50",
-    pink: "bg-pink-400 dark:bg-pink-500 text-pink-50",
-    purple: "bg-purple-400 dark:bg-purple-500 text-purple-50",
-    orange: "bg-orange-400 dark:bg-orange-500 text-orange-50",
-    yellow: "bg-yellow-400 dark:bg-yellow-500 text-yellow-50",
-  };
-
-  const iconColorClass = {
-    blue: "text-blue-400",
-    teal: "text-teal-400",
-    green: "text-green-400",
-    red: "text-red-400",
-    pink: "text-pink-400",
-    purple: "text-purple-400",
-    orange: "text-orange-400",
-    yellow: "text-yellow-400",
-    white: "text-white opacity-80",
-  };
 
   const iconColor = data.color
     ? data.color === "primary"
@@ -147,48 +153,23 @@ export const Icon = ({
         : iconColor
     ];
 
-  const iconSizeClass = {
-    small: "w-8 h-8",
-    medium: "w-12 h-12",
-    large: "w-14 h-14",
-    custom: "",
-  };
-
-  const Component = React.useMemo(() => {
-    if (!IconSVG) return null;
-    if (data.style == "circle") {
-      return (
-        <div
-          data-tinafield={tinaField}
-          className={`relative z-10 inline-flex items-center justify-center flex-shrink-0 ${iconSizeClass[iconSize]} rounded-full ${iconCircleColorClass[iconColor]} ${className}`}
-        >
-          <IconSVG className="w-2/3 h-2/3" />
-        </div>
-      );
-    } else {
-      return (
-        <IconSVG
-          data-tinafield={tinaField}
-          className={`${iconSizeClass[iconSize]} ${iconColorClasses} ${className}`}
-        />
-      );
-    }
-  }, [
-    parentColor,
-    data.style,
-    data.size,
-    data.color,
-    data.name,
-    IconSVG,
-    iconColor,
-  ]);
-
-  return Component;
-};
-
-const randomProperty = (obj) => {
-  let keys = Object.keys(obj);
-  return obj[keys[(keys.length * Math.random()) << 0]];
+  if (data.style == "circle") {
+    return (
+      <div
+        data-tinafield={tinaField}
+        className={`relative z-10 inline-flex items-center justify-center flex-shrink-0 ${iconSizeClass[iconSize]} rounded-full ${iconCircleColorClass[iconColor]} ${className}`}
+      >
+        <IconSVG className="w-2/3 h-2/3" />
+      </div>
+    );
+  } else {
+    return (
+      <IconSVG
+        data-tinafield={tinaField}
+        className={`${iconSizeClass[iconSize]} ${iconColorClasses} ${className}`}
+      />
+    );
+  }
 };
 
 export const iconSchema: TinaField = {

--- a/components/icon.tsx
+++ b/components/icon.tsx
@@ -131,7 +131,6 @@ const iconSizeClass = {
   small: "w-8 h-8",
   medium: "w-12 h-12",
   large: "w-14 h-14",
-  custom: "",
 };
 
 export const Icon = ({
@@ -150,7 +149,7 @@ export const Icon = ({
       ? Object.keys(iconOptions)[0]
       : iconOptions[data.name];
 
-  const iconSize = data.size ? data.size : "large";
+  const iconSizeClasses = data.size && iconSizeClass[data.size];
 
   /* Full class strings are required for Tailwind's just-in-time mode,
      I would love a better solution that doesn't require so much repetition */
@@ -165,7 +164,7 @@ export const Icon = ({
     return (
       <div
         data-tinafield={tinaField}
-        className={`relative z-10 inline-flex items-center justify-center flex-shrink-0 ${iconSizeClass[iconSize]} rounded-full ${iconColorClass[iconColor].circle} ${className}`}
+        className={`relative z-10 inline-flex items-center justify-center flex-shrink-0 ${iconSizeClasses} rounded-full ${iconColorClass[iconColor].circle} ${className}`}
       >
         <IconSVG className="w-2/3 h-2/3" />
       </div>
@@ -181,7 +180,7 @@ export const Icon = ({
     return (
       <IconSVG
         data-tinafield={tinaField}
-        className={`${iconSizeClass[iconSize]} ${iconColorClasses} ${className}`}
+        className={`${iconSizeClasses} ${iconColorClasses} ${className}`}
       />
     );
   }

--- a/components/icon.tsx
+++ b/components/icon.tsx
@@ -87,29 +87,45 @@ const heroIconOptions = {
   aperture: FiAperture,
   tina: TinaIconSvg,
 };
-
-const iconCircleColorClass = {
-  blue: "bg-blue-400 dark:bg-blue-500 text-blue-50",
-  teal: "bg-teal-400 dark:bg-teal-500 text-teal-50",
-  green: "bg-green-400 dark:bg-green-500 text-green-50",
-  red: "bg-red-400 dark:bg-red-500 text-red-50",
-  pink: "bg-pink-400 dark:bg-pink-500 text-pink-50",
-  purple: "bg-purple-400 dark:bg-purple-500 text-purple-50",
-  orange: "bg-orange-400 dark:bg-orange-500 text-orange-50",
-  yellow: "bg-yellow-400 dark:bg-yellow-500 text-yellow-50",
-};
-
-const iconColorClass = {
-  blue: "text-blue-400",
-  teal: "text-teal-400",
-  green: "text-green-400",
-  red: "text-red-400",
-  pink: "text-pink-400",
-  purple: "text-purple-400",
-  orange: "text-orange-400",
-  yellow: "text-yellow-400",
-  white: "text-white opacity-80",
-};
+const iconColorClass: { [name: string]: { regular: string; circle: string } } =
+  {
+    blue: {
+      regular: "text-blue-400",
+      circle: "bg-blue-400 dark:bg-blue-500 text-blue-50",
+    },
+    teal: {
+      regular: "text-teal-400",
+      circle: "bg-teal-400 dark:bg-teal-500 text-teal-50",
+    },
+    green: {
+      regular: "text-green-400",
+      circle: "bg-green-400 dark:bg-green-500 text-green-50",
+    },
+    red: {
+      regular: "text-red-400",
+      circle: "bg-red-400 dark:bg-red-500 text-red-50",
+    },
+    pink: {
+      regular: "text-pink-400",
+      circle: "bg-pink-400 dark:bg-pink-500 text-pink-50",
+    },
+    purple: {
+      regular: "text-purple-400",
+      circle: "bg-purple-400 dark:bg-purple-500 text-purple-50",
+    },
+    orange: {
+      regular: "text-orange-400",
+      circle: "bg-orange-400 dark:bg-orange-500 text-orange-50",
+    },
+    yellow: {
+      regular: "text-yellow-400",
+      circle: "bg-yellow-400 dark:bg-yellow-500 text-yellow-50",
+    },
+    white: {
+      regular: "text-white opacity-80",
+      circle: "bg-white-400 dark:bg-white-500 text-white-50",
+    },
+  };
 
 const iconSizeClass = {
   small: "w-8 h-8",
@@ -145,24 +161,23 @@ export const Icon = ({
       : data.color
     : theme.color;
 
-  const iconColorClasses =
-    iconColorClass[
-      parentColor === "primary" &&
-      (iconColor === theme.color || iconColor === "primary")
-        ? "white"
-        : iconColor
-    ];
-
   if (data.style == "circle") {
     return (
       <div
         data-tinafield={tinaField}
-        className={`relative z-10 inline-flex items-center justify-center flex-shrink-0 ${iconSizeClass[iconSize]} rounded-full ${iconCircleColorClass[iconColor]} ${className}`}
+        className={`relative z-10 inline-flex items-center justify-center flex-shrink-0 ${iconSizeClass[iconSize]} rounded-full ${iconColorClass[iconColor].circle} ${className}`}
       >
         <IconSVG className="w-2/3 h-2/3" />
       </div>
     );
   } else {
+    const iconColorClasses =
+      iconColorClass[
+        parentColor === "primary" &&
+        (iconColor === theme.color || iconColor === "primary")
+          ? "white"
+          : iconColor
+      ].regular;
     return (
       <IconSVG
         data-tinafield={tinaField}

--- a/components/icon.tsx
+++ b/components/icon.tsx
@@ -36,58 +36,34 @@ import {
   HiUser,
 } from "react-icons/hi";
 import { FiAperture } from "react-icons/fi";
-import { Theme, ThemeContext } from "./theme";
-import { FaBeer, FaCoffee, FaPalette } from "react-icons/fa";
-// @ts-ignore
+import { ThemeContext } from "./theme";
+import { FaBeer, FaCoffee } from "react-icons/fa";
 import TinaIconSvg from "../public/tina.svg";
 import type { TinaField } from "tinacms";
-import { cp } from "fs";
 
-const biIconOptions = {
-  code: BiCodeBlock,
-  like: BiLike,
-  map: BiMapAlt,
-  palette: BiPalette,
-  chart: BiPieChartAlt2,
-  pin: BiPin,
-  shield: BiShield,
-  settings: BiSlider,
-  store: BiStore,
-  ball: BiTennisBall,
-  tube: BiTestTube,
-  trophy: BiTrophy,
-  user: BiUserCircle,
-  beer: BiBeer,
-  chat: BiChat,
-  cloud: BiCloud,
-  coffee: BiCoffeeTogo,
-  world: BiWorld,
-  aperture: FiAperture,
-  tina: TinaIconSvg,
+const iconOptions = {
+  code: { bi: BiCodeBlock, hi: HiTerminal },
+  like: { bi: BiLike, hi: HiThumbUp },
+  map: { bi: BiMapAlt, hi: HiMap },
+  palette: { bi: BiPalette, hi: HiColorSwatch },
+  chart: { bi: BiPieChartAlt2, hi: HiChartBar },
+  pin: { bi: BiPin, hi: HiLocationMarker },
+  shield: { bi: BiShield, hi: HiShieldCheck },
+  settings: { bi: BiSlider, hi: HiAdjustments },
+  store: { bi: BiStore, hi: HiShoppingCart },
+  ball: { bi: BiTennisBall, hi: BiTennisBall },
+  tube: { bi: BiTestTube, hi: HiBeaker },
+  trophy: { bi: BiTrophy, hi: ImTrophy },
+  user: { bi: BiUserCircle, hi: HiUser },
+  beer: { bi: BiBeer, hi: FaBeer },
+  chat: { bi: BiChat, hi: HiChatAlt2 },
+  cloud: { bi: BiCloud, hi: HiCloud },
+  coffee: { bi: BiCoffeeTogo, hi: FaCoffee },
+  world: { bi: BiWorld, hi: BiWorld },
+  aperture: { bi: FiAperture, hi: FiAperture },
+  tina: { bi: TinaIconSvg, hi: TinaIconSvg },
 };
 
-const heroIconOptions = {
-  code: HiTerminal,
-  like: HiThumbUp,
-  map: HiMap,
-  palette: HiColorSwatch,
-  chart: HiChartBar,
-  pin: HiLocationMarker,
-  shield: HiShieldCheck,
-  settings: HiAdjustments,
-  store: HiShoppingCart,
-  ball: BiTennisBall,
-  tube: HiBeaker,
-  trophy: ImTrophy,
-  user: HiUser,
-  beer: FaBeer,
-  chat: HiChatAlt2,
-  cloud: HiCloud,
-  coffee: FaCoffee,
-  world: BiWorld,
-  aperture: FiAperture,
-  tina: TinaIconSvg,
-};
 const iconColorClass: { [name: string]: { regular: string; circle: string } } =
   {
     blue: {
@@ -142,13 +118,8 @@ export const Icon = ({
 }) => {
   const theme = React.useContext(ThemeContext);
 
-  const iconOptions =
-    theme.icon === "boxicon" ? biIconOptions : heroIconOptions;
-
-  const IconSVG =
-    !data.name || !iconOptions[data.name]
-      ? Object.keys(iconOptions)[0]
-      : iconOptions[data.name];
+  const iconName = data.name || Object.keys(iconOptions)[0];
+  const IconSVG = iconOptions[iconName][theme.icon === "boxicon" ? "bi" : "hi"];
 
   const iconSizeClasses = data.size && iconSizeClass[data.size];
 
@@ -187,6 +158,10 @@ export const Icon = ({
   }
 };
 
+const formatFieldLabel = (value: string) => {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+};
+
 export const iconSchema: TinaField = {
   type: "object",
   label: "Icon",
@@ -197,7 +172,7 @@ export const iconSchema: TinaField = {
       label: "Color",
       name: "color",
       options: Object.keys(iconColorClass).map((color) => ({
-        label: color.charAt(0).toUpperCase() + color.slice(1),
+        label: formatFieldLabel(color),
         value: color,
       })),
     },
@@ -220,92 +195,10 @@ export const iconSchema: TinaField = {
       type: "string",
       label: "Icon",
       name: "name",
-      options: [
-        {
-          label: "Random",
-          value: "",
-        },
-        {
-          label: "Aperture",
-          value: "aperture",
-        },
-        {
-          label: "Code Block",
-          value: "code",
-        },
-        {
-          label: "Like",
-          value: "like",
-        },
-        {
-          label: "Map",
-          value: "map",
-        },
-        {
-          label: "Palette",
-          value: "palette",
-        },
-        {
-          label: "Pie Chart",
-          value: "chart",
-        },
-        {
-          label: "Pin",
-          value: "pin",
-        },
-        {
-          label: "Shield",
-          value: "shield",
-        },
-        {
-          label: "Setting Sliders",
-          value: "settings",
-        },
-        {
-          label: "Store",
-          value: "store",
-        },
-        {
-          label: "Tennis Ball",
-          value: "ball",
-        },
-        {
-          label: "Test Tube",
-          value: "tube",
-        },
-        {
-          label: "Trophy",
-          value: "trophy",
-        },
-        {
-          label: "User",
-          value: "user",
-        },
-        {
-          label: "Beer",
-          value: "beer",
-        },
-        {
-          label: "Chat",
-          value: "chat",
-        },
-        {
-          label: "Cloud",
-          value: "cloud",
-        },
-        {
-          label: "Coffee",
-          value: "coffee",
-        },
-        {
-          label: "World",
-          value: "world",
-        },
-        {
-          label: "Tina",
-          value: "tina",
-        },
-      ],
+      options: Object.keys(iconOptions).map((icon) => ({
+        label: formatFieldLabel(icon),
+        value: icon,
+      })),
     },
   ],
 };

--- a/components/icon.tsx
+++ b/components/icon.tsx
@@ -41,6 +41,7 @@ import { FaBeer, FaCoffee, FaPalette } from "react-icons/fa";
 // @ts-ignore
 import TinaIconSvg from "../public/tina.svg";
 import type { TinaField } from "tinacms";
+import { cp } from "fs";
 
 const biIconOptions = {
   code: BiCodeBlock,
@@ -195,44 +196,10 @@ export const iconSchema: TinaField = {
       type: "string",
       label: "Color",
       name: "color",
-      options: [
-        {
-          label: "Primary",
-          value: "primary",
-        },
-        {
-          label: "Blue",
-          value: "blue",
-        },
-        {
-          label: "Teal",
-          value: "teal",
-        },
-        {
-          label: "Green",
-          value: "green",
-        },
-        {
-          label: "Red",
-          value: "red",
-        },
-        {
-          label: "Pink",
-          value: "pink",
-        },
-        {
-          label: "Purple",
-          value: "purple",
-        },
-        {
-          label: "Orange",
-          value: "orange",
-        },
-        {
-          label: "Yellow",
-          value: "yellow",
-        },
-      ],
+      options: Object.keys(iconColorClass).map((color) => ({
+        label: color.charAt(0).toUpperCase() + color.slice(1),
+        value: color,
+      })),
     },
     {
       name: "style",


### PR DESCRIPTION
Refactor our Icon component, and fixed a few bugs along the way.

Code cleanup:
- Generate the Tina fields from the type definitions
- Group a few hashes to remove some duplication
- Moved several large constants outside of component
- Removed useMemo (This is a production page, This feels like an over-optimization for edit-mode)

fixes:
- "white" was defined in the circle mode, but not the other
- misleading to use "random" on the frontend to generate an icon (the preview wont reflect the production icon)
- cleanup around "custom" size
- fixed an issue where circle icons wouldn't work in header/footer

Next steps (in a future PR):
- We still have several defensive checks. We should use better types, and make certain Tina fields required
- Several other components likely need a similar refactor