### PR TITLE
Fix issue with hydration on dates

### DIFF
--- a/components/posts/post.tsx
+++ b/components/posts/post.tsx
@@ -58,13 +58,13 @@ const components: Components<{
 
     switch (props.format) {
       case "iso":
-        return <span>{dt.toISOString()}</span>;
+        return <span>{format(dt, "yyyy-MM-dd")}</span>;
       case "utc":
-        return <span>{dt.toUTCString()}</span>;
+        return <span>{format(dt, "eee, dd MMM yyyy HH:mm:ss OOOO")}</span>;
       case "local":
-        return <span>{dt.toLocaleDateString()}</span>;
+        return <span>{format(dt, "P")}</span>;
       default:
-        return <span>{dt.toLocaleDateString()}</span>;
+        return <span>{format(dt, "P")}</span>;
     }
   },
   NewsletterSignup: (props) => {


### PR DESCRIPTION
The date useEffect was rendering a different value than the server, causing this: 
<img width="1065" alt="Screen Shot 2023-06-05 at 10 30 16 AM" src="https://github.com/tinacms/tina-cloud-starter/assets/3323181/dc988eb0-a169-44d4-ace4-2fc91cc4adc1">
