### PR TITLE
NOTICE - Change from forestry to SSW

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 Tina Cloud Starter
-Copyright 2021 Forestry.io Holdings, Inc.
+Copyright 2024 SSW
 
-This product includes software developed at Forestry.io Holdings, Inc. (http://www.forestry.io/).
+This product includes software developed at SSW (http://www.ssw.com.au/).


### PR DESCRIPTION
I noticed the starter was still referencing Forestry