### PR TITLE
Wrap header nav links on mobile

### DIFF
--- a/components/nav/header.tsx
+++ b/components/nav/header.tsx
@@ -38,8 +38,8 @@ export default function Header() {
       className={`relative overflow-hidden bg-gradient-to-b ${headerColorCss}`}
     >
       <Container size="custom" className="py-0 relative z-10 max-w-8xl">
-        <div className="flex items-center justify-between gap-6">
-          <h4 className="select-none text-lg font-bold tracking-tight my-4 transition duration-150 ease-out transform">
+        <div className="flex flex-wrap items-center justify-between lg:gap-6">
+          <h4 className="select-none text-lg font-bold tracking-tight lg:my-4 mt-4 transition duration-150 ease-out transform">
             <Link
               href="/"
               className="flex gap-1 items-center whitespace-nowrap tracking-[.002em]"


### PR DESCRIPTION
Currently, the starter template header nav links will bleed over and be inaccessible on smaller mobile screens

<img width="542" alt="Screenshot 2025-03-01 at 5 40 35 PM" src="https://github.com/user-attachments/assets/efc1e22c-0a57-46f0-a361-8f76b3f66717" />

This pr adjusts the header's flex box to wrap the nav links below the icon and title on smaller dimensioned screens.

<img width="261" alt="Screenshot 2025-03-01 at 5 44 36 PM" src="https://github.com/user-attachments/assets/0b4e9635-2b4a-411d-8c00-9f79b92e0b64" />
