### PR TITLE
pages config - fix issue with visual editing not working

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 NEXT_PUBLIC_TINA_CLIENT_ID=***
 TINA_TOKEN=***
 
+REVALIDATION_SECRET=your-secure-token-here
+
 # This is set by default CI with Netlify/Vercel/Github, but can be overriden
 NEXT_PUBLIC_TINA_BRANCH=***
 # To see the preview functionality

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const secret = searchParams.get('secret');
+  const path = searchParams.get('path');
+
+  // Check for secret to confirm this is a valid request
+  if (secret !== process.env.REVALIDATION_SECRET) {
+    return NextResponse.json({ message: 'Invalid token' }, { status: 401 });
+  }
+
+  if (!path) {
+    return NextResponse.json({ message: 'Path is required' }, { status: 400 });
+  }
+
+  try {
+    // Revalidate the path using the App Router's revalidatePath function
+    console.log(`Revalidating path: ${path}`);
+    revalidatePath(path);
+    return NextResponse.json({ revalidated: true, path });
+  } catch (err) {
+    return NextResponse.json({ message: 'Error revalidating' }, { status: 500 });
+  }
+}

--- a/lib/tina-environment.ts
+++ b/lib/tina-environment.ts
@@ -1,0 +1,32 @@
+// Helper functions to detect editing mode and environment
+
+const checkReferer = (request: Request): boolean => {
+  // Check if the page load was referred from the TinaCMS interface
+  const referer = request.headers.get("referer");
+  if (referer && (referer.includes("/admin/") || referer.endsWith("/admin"))) {
+    return true;
+  }
+  return false;
+};
+
+const isIframe = (request: Request): boolean => {
+  // Check if the request is destined for an iframe
+  // (this header is present in modern browsers)
+  const secFetchDest = request.headers.get("sec-fetch-dest");
+  if (secFetchDest === "iframe") {
+    const secFetchSite = request.headers.get("sec-fetch-site");
+    if (secFetchSite === "same-origin" || secFetchSite === "same-site") {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Determines if the current request is coming from Tina's visual editor
+ */
+export function isEditingMode(request: Request): boolean {
+  const referredFromTina = checkReferer(request);
+  const isTinaIframe = isIframe(request);
+  return referredFromTina && isTinaIframe;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { isEditingMode } from './lib/tina-environment';
+
+export function middleware(request: NextRequest) {
+  // Check if we're in editing mode
+  if (isEditingMode(request)) {
+    console.log('Editing mode detected', request.url);
+
+    // Clone the response
+    const response = NextResponse.next();
+    
+    // Set cache control headers to prevent caching
+    response.headers.set('Cache-Control', 'no-store, must-revalidate');
+    response.headers.set('Pragma', 'no-cache');
+    response.headers.set('Expires', '0');
+    
+    return response;
+  }
+  
+  // For non-editing mode, let Next.js handle caching normally
+  return NextResponse.next();
+}
+
+export const config = {
+// Apply middleware to app routes
+  matcher: '/((?!admin|api|_next/static|_next/image|uploads|favicon.ico).*)',
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/tina/collection/page.ts
+++ b/tina/collection/page.ts
@@ -15,7 +15,7 @@ const Page: Collection = {
       if (document._sys.filename === "home") {
         return `/`;
       }
-      return undefined;
+      return `/${document._sys.filename}`;
     },
   },
   fields: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -20,9 +24,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "strictNullChecks": true
   },
-  "exclude": ["node_modules"],
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"]
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ]
 }

--- a/utils/revalidation.ts
+++ b/utils/revalidation.ts
@@ -1,0 +1,44 @@
+/**
+ * Revalidates Next.js pages by path using the revalidation API
+ * @param paths - The path(s) of the page(s) to revalidate
+ * @returns Promise resolving to boolean indicating success
+ */
+export async function revalidatePage(paths: string | string[]): Promise<boolean> {
+  try {
+    const revalidationSecret = process.env.NEXT_PUBLIC_REVALIDATION_SECRET;
+    
+    if (!revalidationSecret) {
+      console.warn('Revalidation secret not found in environment variables');
+      return false;
+    }
+    
+    const pathsToRevalidate = Array.isArray(paths) ? paths : [paths];
+    console.log('Revalidating paths:', pathsToRevalidate);
+    
+    const results = await Promise.all(
+      pathsToRevalidate.map(async (path) => {
+        const sanitizedPath = path.startsWith('/') ? path : `/${path}`;
+        
+        const response = await fetch(
+          `/api/revalidate?secret=${revalidationSecret}&path=${sanitizedPath}`,
+          { method: 'GET' }
+        );
+        
+        if (!response.ok) {
+          const errorText = await response.text();
+          console.error(`Failed to revalidate path ${path}:`, errorText);
+          return false;
+        }
+        
+        console.log(`Successfully revalidated: ${path}`);
+        return true;
+      })
+    );
+    
+    // Return true only if all revalidations were successful
+    return results.every(result => result === true);
+  } catch (error) {
+    console.error('Error revalidating paths:', error);
+    return false;
+  }
+}


### PR DESCRIPTION
This PR aims to add path revalidation when pages are changed + middleware to prevent caching of pages when viewed in the CMS

This will hopefully enable ISR + ability to view newly added pages before a build is performed.

TODO:

- [ ] fix secret usage (currently symmetrical)
- [ ] test on a deployed site
- [ ] ensure it works in a fully static environment e.g. GitHub pages